### PR TITLE
fix(devcontainer): update backend service dependencies in docker-compose

### DIFF
--- a/.devcontainer/docker-compose.devcontainer.yml
+++ b/.devcontainer/docker-compose.devcontainer.yml
@@ -19,6 +19,9 @@ services:
       - REDIS_URL=redis://redis:6379
       - SHELL=/usr/bin/zsh
     depends_on:
+      backend:
+        condition: service_started
+        restart: true
       postgres:
         condition: service_healthy
       redis:
@@ -28,8 +31,6 @@ services:
 
   # Override backend service for devcontainer compatibility
   backend:
-    profiles:
-      - standalone
     ports:
       - "3001:3001"
 


### PR DESCRIPTION
This pull request updates the `docker-compose.devcontainer.yml` file to improve service dependency handling and simplify the backend service configuration for development containers.

### Service dependency improvements:

* Added a `depends_on` condition for the `backend` service to ensure it starts before dependent services and included a `restart: true` policy for better reliability. (`[.devcontainer/docker-compose.devcontainer.ymlR22-R24](diffhunk://#diff-6c18c2f55475f62e07caaa5b1e163164128714b6a2130c91879d1c3318e13217R22-R24)`)

### Backend service simplification:

* Removed the `profiles` configuration from the `backend` service, as it is unnecessary for the devcontainer setup. (`[.devcontainer/docker-compose.devcontainer.ymlL31-L32](diffhunk://#diff-6c18c2f55475f62e07caaa5b1e163164128714b6a2130c91879d1c3318e13217L31-L32)`)